### PR TITLE
10.0.0-preview.4.25258.110.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <PlatformVersion>10.0.0-preview.3.25171.5</PlatformVersion>
+    <PlatformVersion>10.0.0-preview.4.25258.110</PlatformVersion>
     <HybridCachePlatformVersion>9.3.0</HybridCachePlatformVersion>
     <ResiliencePlatformVersion>9.3.0</ResiliencePlatformVersion>
   </PropertyGroup>
@@ -38,7 +38,7 @@
   
   <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
     <!-- Properties for .NET Framework -->
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.6.1" />
     <PackageReference Include="Microsoft.Bcl.Memory" Version="$(PlatformVersion)" />
     <PackageReference Include="IsExternalInit" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Axion.Extensions.Caching.Azure.Storage.Blobs/version.json
+++ b/src/Axion.Extensions.Caching.Azure.Storage.Blobs/version.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "10.0.0-preview.3.25171.5.0",
+  "version": "10.0.0-preview.4.25258.110.0",
   "inherit": true
 }

--- a/src/Axion.Extensions.Caching.Hybrid.Serialization.Http/System/Int32Extensions.cs
+++ b/src/Axion.Extensions.Caching.Hybrid.Serialization.Http/System/Int32Extensions.cs
@@ -9,65 +9,67 @@ namespace System;
 
 static class Int32Extensions
 {
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int WriteHexTo(this int value, Span<byte> buffer)
+    extension(int value)
     {
-        var multipler = value.HexMultiplier();
-        var index = 0;
-
-        while (multipler > 0)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int WriteHexTo(Span<byte> buffer)
         {
-            var d = Math.DivRem(value, multipler, out value);
-            buffer[index++] = (byte)(d < 10 ? d + '0' : d + 'a' - 10);
-            multipler >>= 4;
+            var multipler = value.HexMultiplier();
+            var index = 0;
+
+            while (multipler > 0)
+            {
+                var d = Math.DivRem(value, multipler, out value);
+                buffer[index++] = (byte)(d < 10 ? d + '0' : d + 'a' - 10);
+                multipler >>= 4;
+            }
+
+            return index;
         }
 
-        return index;
-    }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int HexMultiplier() =>
+            1 << ((value.CountOfHexDigits() - 1) << 2);
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int HexMultiplier(this int value) =>
-        1 << ((value.CountOfHexDigits() - 1) << 2);
-
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int CountOfHexDigits(this int value)
-    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int CountOfHexDigits()
+        {
 #if NETCOREAPP3_0_OR_GREATER
-        return (BitOperations.Log2((uint)value) >> 2) + 1;
+            return (BitOperations.Log2((uint)value) >> 2) + 1;
 #else
-        if (value < 16)
-        {
-            return 1;
-        }
-        else if (value < 16 * 16)
-        {
-            return 2;
-        }
-        else if (value < 16 * 16 * 16)
-        {
-            return 3;
-        }
-        else if (value < 16 * 16 * 16)
-        {
-            return 4;
-        }
-        else if (value < 16 * 16 * 16 * 16)
-        {
-            return 5;
-        }
-        else if (value < 16 * 16 * 16 * 16)
-        {
-            return 6;
-        }
-        else if (value < 16 * 16 * 16 * 16 * 16)
-        {
-            return 7;
-        }
-        else
-        {
-            return 8;
-        }
+            if (value < 16)
+            {
+                return 1;
+            }
+            else if (value < 16 * 16)
+            {
+                return 2;
+            }
+            else if (value < 16 * 16 * 16)
+            {
+                return 3;
+            }
+            else if (value < 16 * 16 * 16)
+            {
+                return 4;
+            }
+            else if (value < 16 * 16 * 16 * 16)
+            {
+                return 5;
+            }
+            else if (value < 16 * 16 * 16 * 16)
+            {
+                return 6;
+            }
+            else if (value < 16 * 16 * 16 * 16 * 16)
+            {
+                return 7;
+            }
+            else
+            {
+                return 8;
+            }
 #endif
+        }
     }
 }

--- a/src/Axion.Extensions.Caching.Hybrid.Serialization.Http/version.json
+++ b/src/Axion.Extensions.Caching.Hybrid.Serialization.Http/version.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "10.0.0-preview.3.25171.5.0",
+  "version": "10.0.0-preview.4.25258.110.0",
   "inherit": true
 }

--- a/src/Axion.Extensions.Caching.Transformed/version.json
+++ b/src/Axion.Extensions.Caching.Transformed/version.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "10.0.0-preview.3.25171.5.0",
+  "version": "10.0.0-preview.4.25258.110.0",
   "inherit": true
 }

--- a/src/Axion.Extensions.DependencyInjection/version.json
+++ b/src/Axion.Extensions.DependencyInjection/version.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "10.0.0-preview.3.25171.5.0",
+  "version": "10.0.0-preview.4.25258.110.0",
   "inherit": true
 }

--- a/src/Axion.Extensions.FileProviders.GitHub/version.json
+++ b/src/Axion.Extensions.FileProviders.GitHub/version.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "10.0.0-preview.3.25171.5.0",
+  "version": "10.0.0-preview.4.25258.110.0",
   "inherit": true
 }


### PR DESCRIPTION
Update platform versions and refactor Int32Extensions

- Updated `PlatformVersion` in `Directory.Build.props` to `10.0.0-preview.4.25258.110`.
- Upgraded `System.ValueTuple` package version to `4.6.1`.
- Changed `version` in `version.json` to `10.0.0-preview.4.25258.110.0`.
- Refactored methods in `Int32Extensions.cs` from static to instance methods for improved readability and maintainability.